### PR TITLE
feat: implement gallery endpoint

### DIFF
--- a/server.js
+++ b/server.js
@@ -70,6 +70,194 @@ app.post("/upload", authenticate, upload.single("media"), async (req, res) => {
   res.send("File uploaded");
 });
 
+app.get("/gallery", async (req, res) => {
+  await db.read();
+  const files = db.data.files.sort(
+    (a, b) => new Date(b.uploadedAt) - new Date(a.uploadedAt)
+  );
+
+  // Group by uploaded date (formatted)
+  const grouped = files.reduce((acc, file) => {
+    const date = new Date(file.uploadedAt);
+    const formattedDate = date.toLocaleDateString("en-US", {
+      weekday: "short",
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    }); // e.g., "Mon, Jul 15, 2024"
+
+    acc[formattedDate] = acc[formattedDate] || [];
+    acc[formattedDate].push(file);
+    return acc;
+  }, {});
+
+  const fileSections = Object.entries(grouped).map(([date, files]) => {
+    const cards = files
+      .map((file) => {
+        const relPath = path
+          .relative(path.join(__dirname, "uploads"), file.path)
+          .replace(/\\/g, "/");
+        const fileUrl = `/file/${relPath}`;
+        const isImage = /\.(jpg|jpeg|png|gif|webp)$/i.test(file.original);
+        const isVideo = /\.(mp4|mov|m4v|hevc|heic)$/i.test(file.original);
+
+        return `
+        <div class="card" onclick="openPreview('${fileUrl}', '${file.original}', ${isImage})">
+          ${isImage ? `<img src="${fileUrl}" loading="lazy" />` : ""}
+          ${isVideo ? `<video src="${fileUrl}" muted playsinline></video>` : ""}
+        </div>
+      `;
+      })
+      .join("");
+
+    return `
+      <div class="section">
+        <div class="section-date">${date}</div>
+        <div class="grid">${cards}</div>
+      </div>
+    `;
+  }).join("\n");
+
+  res.send(`
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+      <meta charset="UTF-8" />
+      <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+      <title>Gallery</title>
+      <style>
+        * {
+          box-sizing: border-box;
+        }
+
+        body {
+          margin: 0;
+          font-family: 'Inter', 'Segoe UI', sans-serif;
+          background: linear-gradient(135deg, #0f0f0f, #1e1e2f);
+          color: #f1f1f1;
+          padding: 16px;
+        }
+
+        h1 {
+          text-align: center;
+          margin-bottom: 32px;
+          font-size: 2rem;
+          background: linear-gradient(to right, #facc15, #f472b6);
+          -webkit-background-clip: text;
+          -webkit-text-fill-color: transparent;
+        }
+
+        .section {
+          margin-bottom: 32px;
+        }
+
+        .section-date {
+          font-size: 15px;
+          font-weight: 500;
+          color: #aaa;
+          margin: 12px 6px;
+        }
+
+        .grid {
+          display: grid;
+          grid-template-columns: repeat(auto-fill, minmax(48%, 1fr));
+          gap: 8px;
+        }
+
+        .card {
+          aspect-ratio: 1 / 1;
+          border-radius: 8px;
+          overflow: hidden;
+          background: rgba(255, 255, 255, 0.04);
+          box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+          transition: transform 0.2s;
+          cursor: pointer;
+        }
+
+        .card:hover {
+          transform: scale(1.02);
+        }
+
+        .card img,
+        .card video {
+          width: 100%;
+          height: 100%;
+          object-fit: cover;
+          display: block;
+        }
+
+        .preview-overlay {
+          position: fixed;
+          top: 0; left: 0;
+          width: 100%; height: 100%;
+          background: rgba(0, 0, 0, 0.85);
+          display: none;
+          align-items: center;
+          justify-content: center;
+          z-index: 1000;
+        }
+
+        .preview-overlay.active {
+          display: flex;
+        }
+
+        .preview-content {
+          max-width: 90%;
+          max-height: 90%;
+          position: relative;
+        }
+
+        .preview-content img,
+        .preview-content video {
+          max-width: 100%;
+          max-height: 100%;
+          border-radius: 12px;
+          box-shadow: 0 0 24px rgba(255, 255, 255, 0.1);
+        }
+
+        .close-btn {
+          position: absolute;
+          top: -32px;
+          right: 0;
+          font-size: 28px;
+          color: white;
+          cursor: pointer;
+        }
+
+        @media (min-width: 600px) {
+          .grid {
+            grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+          }
+        }
+      </style>
+    </head>
+    <body>
+      ${fileSections}
+
+      <div class="preview-overlay" id="previewOverlay" onclick="closePreview()">
+        <div class="preview-content" onclick="event.stopPropagation()">
+          <span class="close-btn" onclick="closePreview()">&times;</span>
+          <div id="previewMedia"></div>
+        </div>
+      </div>
+
+      <script>
+        function openPreview(url, name, isImage) {
+          const container = document.getElementById("previewMedia");
+          container.innerHTML = isImage
+            ? \`<img src="\${url}" alt="\${name}" />\`
+            : \`<video controls autoplay src="\${url}"></video>\`;
+          document.getElementById("previewOverlay").classList.add("active");
+        }
+
+        function closePreview() {
+          document.getElementById("previewOverlay").classList.remove("active");
+        }
+      </script>
+    </body>
+    </html>
+  `);
+});
 
 function authenticate(req, res, next) {
   const token = req.headers["authorization"];


### PR DESCRIPTION
# Add `/gallery` endpoint for media browsing

## Overview

This adds a `/gallery` endpoint that displays uploaded media files grouped by upload date in a clean, responsive gallery view.

## Features

- Groups files by upload date (e.g., "Mon, Jul 15, 2024")
- Supports images (`jpg`, `png`, etc.) and videos (`mp4`, `mov`, etc.)
- Clickable thumbnails open a preview overlay for full-size images or video playback
- Responsive grid layout with modern dark-themed styling

## Details

- Reads and sorts files from `db.json`
- Generates HTML, CSS, and JS dynamically to show the gallery and preview
- Serves media files via existing `/file` static route

## Testing

1. Upload files via `/upload`
2. Visit `/gallery` to see media grouped by date
3. Click on items to preview

---

This improves browsing and previewing of backed-up media files.
